### PR TITLE
fix: remove Enzyme error hint for runtime activity

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/init.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/init.jl
@@ -5,6 +5,9 @@ function HINT_START(option)
 end
 
 function __init__()
+    if !isdefined(Base.Experimental, :register_error_hint)
+        return nothing
+    end
     # robust against internal changes
     condition = (
         isdefined(Enzyme, :Compiler) &&
@@ -28,16 +31,8 @@ function __init__()
                         bold=true,
                     )
                     printstyled(io, HINT_END; italic=true)
-                elseif occursin("EnzymeRuntimeActivityError", string(nameof(T)))
-                    printstyled(io, HINT_START("mode"); bold=true)
-                    printstyled(
-                        io,
-                        "\n\n\tAutoEnzyme(; mode=Enzyme.set_runtime_activity(Enzyme.Forward))\n\tAutoEnzyme(; mode=Enzyme.set_runtime_activity(Enzyme.Reverse))";
-                        color=:cyan,
-                        bold=true,
-                    )
-                    printstyled(io, HINT_END; italic=true)
                 end
+                # EnzymeRuntimeActivityError is no longer a concrete type since https://github.com/EnzymeAD/Enzyme.jl/pull/2555 (now a UnionAll) so we cannot define a hint
             end
         end
     end

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -152,7 +152,6 @@ end
         @test occursin("AutoEnzyme", msg)
         @test occursin("function_annotation", msg)
         @test occursin("ADTypes", msg)
-        @test occursin("DifferentiationInterface", msg)
     end
 
     @testset "RuntimeActivityError" begin
@@ -181,11 +180,8 @@ end
         catch e
         end
         msg = sprint(showerror, e)
-        @test occursin("AutoEnzyme", msg)
-        @test occursin("mode", msg)
-        @test occursin("set_runtime_activity", msg)
-        @test occursin("ADTypes", msg)
-        @test occursin("DifferentiationInterface", msg)
+        @test_broken occursin("AutoEnzyme", msg)
+        @test_broken occursin("ADTypes", msg)
     end
 end
 


### PR DESCRIPTION
The missing hint was spotted in #851. It is due to the combination of:

- https://github.com/JuliaLang/julia/issues/58367 (error hints only work for concrete types)
- https://github.com/EnzymeAD/Enzyme.jl/pull/2555 (`EnzymeRuntimeActivityError` is now a `UnionAll` type)