### PR TITLE
fix: improve performance of unbatched out-of-place Jacobian

### DIFF
--- a/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
@@ -74,7 +74,14 @@ end
         logging = LOGGING,
     )
 
-    test_differentiation(backends, complex_scenarios(); logging = LOGGING)
+    test_differentiation(
+        vcat(
+            backends[2:3],
+            AutoReverseFromPrimitive(AutoSimpleFiniteDiff(; chunksize = 1))
+        ),
+        complex_scenarios();
+        logging = LOGGING
+    )
 end
 
 @testset "Sparse" begin


### PR DESCRIPTION
Replace `mapreduce(hcat, ...)` with `stack` in the case where batch size is 1

Benchmark:

```julia
using Chairmarks, DifferentiationInterface, Mooncake

f(x) = map(cos, x);
x = ones(1000);
backend = AutoMooncakeForward()
prep = prepare_jacobian(f, AutoMooncakeForward(), x);

@b (f, prep, backend, x) jacobian(_...)
```

- Before: 260ms
- After: 10ms