### PR TITLE
feat: allow non-numeric arguments with `AutoSymbolics`

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/DifferentiationInterfaceSymbolicsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/DifferentiationInterfaceSymbolicsExt.jl
@@ -26,6 +26,7 @@ dense_ad(backend::AutoSparse{<:AutoSymbolics}) = ADTypes.dense_ad(backend)
 
 variablize(::Number, name::Symbol) = variable(name)
 variablize(x::AbstractArray, name::Symbol) = variables(name, axes(x)...)
+variablize(::T, name::Symbol) where {T} = variable(name; T)
 
 function variablize(contexts::NTuple{C, DI.Context}) where {C}
     return ntuple(Val(C)) do k

--- a/DifferentiationInterface/test/Back/Symbolics/test.jl
+++ b/DifferentiationInterface/test/Back/Symbolics/test.jl
@@ -43,21 +43,21 @@ test_differentiation(
 end
 
 @testset "Non-numeric arguments" begin
-    function differentiate_me!(out, x, dummy)
-        @assert dummy isa Any # Just to use it somewhere
+    function differentiate_me!(out, x, c)
+        @assert c isa Any # Just to use it somewhere
         return copyto!(out, x)
     end
-    function differentiate_me(x, dummy)
+    function differentiate_me(x, c)
         tmp = similar(x)
-        differentiate_me!(tmp, x, dummy)
+        differentiate_me!(tmp, x, c)
         return tmp
     end
     x = rand(10)
     xbuffer = copy(x)
-    dummy = "DUMMY"
+    c = "I am a string"
     backend = AutoSymbolics()
-    jac_prep = prepare_jacobian(differentiate_me, backend, x, Constant(dummy))
-    jac!_prep = prepare_jacobian(differentiate_me!, xbuffer, backend, x, Constant(dummy))
-    @test jacobian(differentiate_me, jac_prep, backend, x, Constant(dummy)) ≈ I
-    @test jacobian(differentiate_me!, xbuffer, jac!_prep, backend, x, Constant(dummy)) ≈ I
+    jac_prep = prepare_jacobian(differentiate_me, backend, x, Constant(c))
+    jac!_prep = prepare_jacobian(differentiate_me!, xbuffer, backend, x, Constant(c))
+    @test jacobian(differentiate_me, jac_prep, backend, x, Constant(c)) ≈ I
+    @test jacobian(differentiate_me!, xbuffer, jac!_prep, backend, x, Constant(c)) ≈ I
 end

--- a/DifferentiationInterface/test/Back/Symbolics/test.jl
+++ b/DifferentiationInterface/test/Back/Symbolics/test.jl
@@ -41,3 +41,23 @@ test_differentiation(
     @test sparsity_pattern(jac!_prep) == Diagonal(trues(10))
     @test sparsity_pattern(hess_prep) == Diagonal(trues(10))
 end
+
+@testset "Non-numeric arguments" begin
+    function differentiate_me!(out, x, dummy)
+        @assert dummy isa Any # Just to use it somewhere
+        return copyto!(out, x)
+    end
+    function differentiate_me(x, dummy)
+        tmp = similar(x)
+        differentiate_me!(tmp, x, dummy)
+        return tmp
+    end
+    x = rand(10)
+    xbuffer = copy(x)
+    dummy = "DUMMY"
+    backend = AutoSymbolics()
+    jac_prep = prepare_jacobian(differentiate_me, backend, x, Constant(dummy))
+    jac!_prep = prepare_jacobian(differentiate_me!, xbuffer, backend, x, Constant(dummy))
+    @test jacobian(differentiate_me, jac_prep, backend, x, Constant(dummy)) ≈ I
+    @test jacobian(differentiate_me!, xbuffer, jac!_prep, backend, x, Constant(dummy)) ≈ I
+end


### PR DESCRIPTION
This allows DI to handle functions accepting non-numeric arguments with `AutoSymbolics` if they are "sufficiently nice". Typically this means that they only pass the non-numeric arguments to registered functions, or use the incoming support for symbolic structs in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1707.