### PR TITLE
Fix inner preparation behavior for Mooncake

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.7.14"
+version = "0.7.13"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.7.13"
+version = "0.7.14"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/DifferentiationInterfaceMooncakeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/DifferentiationInterfaceMooncakeExt.jl
@@ -34,6 +34,7 @@ using Mooncake:
 const AnyAutoMooncake{C} = Union{AutoMooncake{C}, AutoMooncakeForward{C}}
 
 DI.check_available(::AnyAutoMooncake{C}) where {C} = true
+DI.inner_preparation_behavior(::AutoMooncakeForward) = DI.PrepareInnerSimple()
 
 include("utils.jl")
 include("onearg.jl")

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -32,15 +32,15 @@ EXCLUDED = @static if VERSION ≥ v"1.11-" && VERSION ≤ v"1.12-"
     # testing only :hessian on 1.11 due to an opaque closure bug.  
     # This is potentially the same issue as discussed in 
     # https://github.com/chalk-lab/MistyClosures.jl/pull/12#issue-3278662295
-    [FIRST_ORDER..., :hvp, :second_derivative],
+    [FIRST_ORDER..., :hvp, :second_derivative]
 else
-    [FIRST_ORDER...],
+    [FIRST_ORDER...]
 end
 
 # Test second-order differentiation (forward-over-reverse)
 test_differentiation(
     [SecondOrder(AutoMooncakeForward(; config=nothing), AutoMooncake(; config=nothing))],
-    excluded=EXCLUDED
+    excluded=EXCLUDED,
     logging=true,
 )
 

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -28,6 +28,22 @@ test_differentiation(
     logging = LOGGING,
 );
 
+EXCLUDED = @static if VERSION ≥ v"1.11-" && VERSION ≤ v"1.12-"
+    # testing only :hessian on 1.11 due to an opaque closure bug.  
+    # This is potentially the same issue as discussed in 
+    # https://github.com/chalk-lab/MistyClosures.jl/pull/12#issue-3278662295
+    [FIRST_ORDER..., :hvp, :second_derivative],
+else
+    [FIRST_ORDER...],
+end
+
+# Test second-order differentiation (forward-over-reverse)
+test_differentiation(
+    [SecondOrder(AutoMooncakeForward(; config=nothing), AutoMooncake(; config=nothing))],
+    excluded=EXCLUDED
+    logging=true,
+)
+
 @testset "NamedTuples" begin
     ps = (; A = rand(5), B = rand(5))
     myfun(ps) = sum(ps.A .* ps.B)

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -29,8 +29,8 @@ test_differentiation(
 );
 
 EXCLUDED = @static if VERSION ≥ v"1.11-" && VERSION ≤ v"1.12-"
-    # testing only :hessian on 1.11 due to an opaque closure bug.  
-    # This is potentially the same issue as discussed in 
+    # testing only :hessian on 1.11 due to an opaque closure bug.
+    # this is potentially the same issue as discussed in
     # https://github.com/chalk-lab/MistyClosures.jl/pull/12#issue-3278662295
     [FIRST_ORDER..., :hvp, :second_derivative]
 else
@@ -39,9 +39,9 @@ end
 
 # Test second-order differentiation (forward-over-reverse)
 test_differentiation(
-    [SecondOrder(AutoMooncakeForward(; config=nothing), AutoMooncake(; config=nothing))],
-    excluded=EXCLUDED,
-    logging=true,
+    [SecondOrder(AutoMooncakeForward(; config = nothing), AutoMooncake(; config = nothing))],
+    excluded = EXCLUDED,
+    logging = true,
 )
 
 @testset "NamedTuples" begin


### PR DESCRIPTION
See, https://github.com/chalk-lab/Mooncake.jl/pull/878#issuecomment-3696647362

> In the case of Mooncake, we're dealing with source transformation, so DI.PrepareInnerSimple() is more appropriate, good job for finding that.


*Edit:* While no longer strictly necessary following PR [#926](https://github.com/chalk-lab/Mooncake.jl/pull/926) of Mooncake.jl, this remains useful as an optimisation. 