### PR TITLE
test: bypass failing Enzyme test until upstream fix

### DIFF
--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -78,11 +78,15 @@ end
     )
 
     test_differentiation(
-        # TODO: replace with AutoEnzyme() when https://github.com/EnzymeAD/Enzyme.jl/issues/2854 is fixed
-        SecondOrder(
-            AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Forward)),
-            AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
-        ),
+        # TODO: simplify when https://github.com/EnzymeAD/Enzyme.jl/issues/2854 and https://github.com/EnzymeAD/Enzyme.jl/issues/2925 are fixed
+        if VERSION >= v"1.11"
+            SecondOrder(
+                AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Forward)),
+                AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
+            )
+        else
+            AutoEnzyme()
+        end,
         default_scenarios(; include_normal = false, include_constantified = false, include_cachified = true);
         excluded = vcat(FIRST_ORDER, :second_derivative),
         logging = LOGGING,

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -64,8 +64,25 @@ end
 
 @testset "Second order" begin
     test_differentiation(
+        AutoEnzyme(),
+        default_scenarios(; include_constantified = true, include_cachified = true);
+        excluded = vcat(FIRST_ORDER, :hvp, :hessian),
+        logging = LOGGING,
+    )
+
+    test_differentiation(
+        # TODO: replace with AutoEnzyme() when https://github.com/EnzymeAD/Enzyme.jl/issues/2854 is fixed
+        SecondOrder(
+            AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Forward)),
+            AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
+        ),
+        default_scenarios(; include_constantified = true, include_cachified = true);
+        excluded = vcat(FIRST_ORDER, :second_derivative),
+        logging = LOGGING,
+    )
+
+    test_differentiation(
         [
-            AutoEnzyme(),
             SecondOrder(
                 AutoEnzyme(; mode = Enzyme.Reverse), AutoEnzyme(; mode = Enzyme.Forward)
             ),

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -71,12 +71,19 @@ end
     )
 
     test_differentiation(
+        AutoEnzyme(),
+        default_scenarios(; include_constantified = true);
+        excluded = vcat(FIRST_ORDER, :second_derivative),
+        logging = LOGGING,
+    )
+
+    test_differentiation(
         # TODO: replace with AutoEnzyme() when https://github.com/EnzymeAD/Enzyme.jl/issues/2854 is fixed
         SecondOrder(
             AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Forward)),
             AutoEnzyme(; mode = Enzyme.set_runtime_activity(Enzyme.Reverse))
         ),
-        default_scenarios(; include_constantified = true, include_cachified = true);
+        default_scenarios(; include_normal = false, include_constantified = false, include_cachified = true);
         excluded = vcat(FIRST_ORDER, :second_derivative),
         logging = LOGGING,
     )


### PR DESCRIPTION
Activate runtime activity in some second-order tests

To undo once https://github.com/EnzymeAD/Enzyme.jl/issues/2854 has been addressed