### PR TITLE
docs: fix Hessian docstrings

### DIFF
--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -12,7 +12,7 @@ function prepare_hessian(
 end
 
 """
-    prepare!_hessian(f, backend, x, [contexts...]) -> new_prep
+    prepare!_hessian(f, prep, backend, x, [contexts...]) -> new_prep
 
 $(docstring_prepare!("hessian"))
 """

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -17,9 +17,9 @@ function prepare_hvp(
 end
 
 """
-    prepare!_hvp(f, backend, x, tx, [contexts...]) -> new_prep
+    prepare!_hvp(f, prep, backend, x, tx, [contexts...]) -> new_prep
 
-$(docstring_prepare("hvp"))
+$(docstring_prepare!("hvp"))
 """
 function prepare!_hvp(
         f::F,


### PR DESCRIPTION
Applies two fixes to the Hessian and HVP docs:
- Docstrings for `prepare!_hessian` and `prepare!_hvp` were missing the `prep` argument
- `prepare!_hvp` called `docstring_prepare` instead of `docstring_prepare!`