### PR TITLE
doc: add docstrings to the result anlysis methods for sparse matrix preparations

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -19,20 +19,82 @@ import SparseMatrixColorings as SMC
 
 abstract type SMCSparseJacobianPrep{SIG} <: DI.SparseJacobianPrep{SIG} end
 
+"""
+    SMC.sparsity_pattern(prep::DI.SparseJacobianPrep)
+
+Return the sparsity pattern of a sparse `prep` object created by [`prepare_jacobian`](@ref).
+"""
 SMC.sparsity_pattern(prep::DI.SparseJacobianPrep) = prep.sparsity
+
+"""
+    SMC.column_colors(prep::DI.SparseJacobianPrep)
+
+Return the column colors of a sparse `prep` object created by [`prepare_jacobian`](@ref).
+"""
 SMC.column_colors(prep::DI.SparseJacobianPrep) = column_colors(prep.coloring_result)
+
+"""
+    SMC.column_groups(prep::DI.SparseJacobianPrep)
+
+Return the column groups of a sparse `prep` object created by [`prepare_jacobian`](@ref).
+"""
 SMC.column_groups(prep::DI.SparseJacobianPrep) = column_groups(prep.coloring_result)
+
+"""
+    SMC.row_colors(prep::DI.SparseJacobianPrep)
+
+Return the row colors of a sparse `prep` object created by [`prepare_jacobian`](@ref).
+"""
 SMC.row_colors(prep::DI.SparseJacobianPrep) = row_colors(prep.coloring_result)
+
+"""
+    SMC.row_groups(prep::DI.SparseJacobianPrep)
+
+Return the row groups of a sparse `prep` object created by [`prepare_jacobian`](@ref).
+"""
 SMC.row_groups(prep::DI.SparseJacobianPrep) = row_groups(prep.coloring_result)
+
+"""
+    SMC.ncolors(prep::DI.SparseJacobianPrep)
+
+Return the number of colors of a sparse `prep` object created by [`prepare_jacobian`](@ref).
+"""
 SMC.ncolors(prep::DI.SparseJacobianPrep) = ncolors(prep.coloring_result)
 
+
+
+"""
+    SMC.sparsity_pattern(prep::DI.SparseHessianPrep)
+
+Return the sparsity pattern of a sparse `prep` object created by [`prepare_hessian`](@ref).
+"""
 SMC.sparsity_pattern(prep::DI.SparseHessianPrep) = prep.sparsity
+
+"""
+    SMC.column_colors(prep::DI.SparseHessianPrep)
+
+Return the column colors of a sparse `prep` object created by [`prepare_hessian`](@ref).
+"""
 SMC.column_colors(prep::DI.SparseHessianPrep) = column_colors(prep.coloring_result)
+
+"""
+    SMC.column_groups(prep::DI.SparseHessianPrep)
+
+Return the column groups of a sparse `prep` object created by [`prepare_hessian`](@ref).
+"""
 SMC.column_groups(prep::DI.SparseHessianPrep) = column_groups(prep.coloring_result)
+
+"""
+    SMC.ncolors(prep::DI.SparseHessianPrep)
+
+Return the number of colors of a sparse `prep` object created by [`prepare_hessian`](@ref).
+"""
 SMC.ncolors(prep::DI.SparseHessianPrep) = ncolors(prep.coloring_result)
+
 
 include("jacobian.jl")
 include("jacobian_mixed.jl")
 include("hessian.jl")
+
 
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -62,7 +62,6 @@ Return the number of colors of a sparse `prep` object created by [`prepare_jacob
 SMC.ncolors(prep::DI.SparseJacobianPrep) = ncolors(prep.coloring_result)
 
 
-
 """
     SMC.sparsity_pattern(prep::DI.SparseHessianPrep)
 


### PR DESCRIPTION
Closes #981 

This PR add docstrings to the methods :

1. `SMC.sparsity_pattern(prep::DI.SparseJacobianPrep)`
2. `SMC.column_colors(prep::DI.SparseJacobianPrep)`
3. `SMC.column_groups(prep::DI.SparseJacobianPrep)`
4. `SMC.row_colors(prep::DI.SparseJacobianPrep)`
5. `SMC.row_groups(prep::DI.SparseJacobianPrep)`
6. `SMC.ncolors(prep::DI.SparseJacobianPrep)`
7. `SMC.sparsity_pattern(prep::DI.SparseHessianPrep)`
8. `SMC.column_colors(prep::DI.SparseHessianPrep)`
9. `SMC.column_groups(prep::DI.SparseHessianPrep)`
10. `SMC.ncolors(prep::DI.SparseHessianPrep)`

Having them documented send a signal that the methods can be safely used publicly.